### PR TITLE
WIP: Pgr test workingdays

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg |  apt-key add -
 RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" |  tee /etc/apt/sources.list.d/yarn.list
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
+RUN curl -o /usr/local/bin/rmate https://raw.githubusercontent.com/aurora/rmate/master/rmate && chmod +x /usr/local/bin/rmate
+
 RUN apt-get -y update && apt-get -y --force-yes upgrade && \
     apt-get install -y --force-yes php7.1-bcmath php7.1-bz2 php7.1-cli php7.1-common php7.1-curl \
                 php7.1-cgi php7.1-dev php7.1-fpm php7.1-gd php7.1-gmp php7.1-imap php7.1-intl \

--- a/app/Http/Controllers/ExternalAPI.php
+++ b/app/Http/Controllers/ExternalAPI.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use GuzzleHttp\Client;
+use Illuminate\Http\Request;
+
+class ExternalAPI extends Controller
+{
+    public function getBankHolidays()
+    {
+        $client = new Client();
+        $res = $client->request('GET', 'https://www.gov.uk/bank-holidays.json');
+        return $res->getBody();
+    }
+
+}

--- a/app/Http/Controllers/ExternalAPI.php
+++ b/app/Http/Controllers/ExternalAPI.php
@@ -11,7 +11,7 @@ class ExternalAPI extends Controller
     {
         $client = new Client();
         $res = $client->request('GET', 'https://www.gov.uk/bank-holidays.json');
-        return $res->getBody();
+        return response($res->getBody(), 200) -> header('Content-Type', 'text/json');;
     }
 
 }

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -79,7 +79,7 @@ class StudentController extends Controller
         $this->authorise('view', $student);
         session()->flash('student', $student);
 
-        if ($student->records()->count() === 1 && ! auth()->user()->can('manage', Student::class)) {
+        if ($student->records()->count() === 1) {
             return redirect()->route('student.record.show',
                 [$student->university_id, $student->record()->slug()]);
         }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -18,7 +18,6 @@ Dropzone.autoDiscover = false;
 function working_days(from, to, cb) {
   function get_bank_holidays(cb) {
     $.getJSON('https://lcas.lincoln.ac.uk/pgr-test/api/holidays', null, function(data) {
-      banner.addClass("alt");
       //console.log(data);
       var event_lst = data['england-and-wales'].events;
       var holidays = [];
@@ -59,9 +58,12 @@ function working_days(from, to, cb) {
 }
 
 function propose_duration(selector) {
-  var from = $('#from').val();
-  var to = $('#to').val();
+  var s_from = $('#from').val().split('-');
+  var s_to = $('#to').val().split('-');
+  var from = new Date(s_from[0], s_from[1]-1, s_from[2]);
+  var to = new Date(s_to[0], s_to[1]-1, s_to[2]);
   console.log(from);
+  console.log(to);
   working_days(from, to, function (wd) {
     $(selector).val(wd);
   });
@@ -116,7 +118,7 @@ $(function() {
     $('#to_datepicker').datepicker({ changeMonth: true, changeYear: true, inline: true,
         dateFormat: "yy-mm-dd", altField: "#d", altFormat: "yy-mm-dd" });
     $('#to').change(function(){ $('#to_datepicker').datepicker('setDate', $(this).val()); });
-    $('#to_datepicker').change(function(){ $('#to').attr('value',$(this).val()); });
+    $('#to_datepicker').change(function(){ $('#to').attr('value',$(this).val()); propose_duration('#duration')});
     $('#to_datepicker').datepicker('setDate', $('#to').val());
 
 

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -15,6 +15,59 @@ import Dropzone from 'dropzone';
 
 Dropzone.autoDiscover = false;
 
+function working_days(from, to, cb) {
+  function get_bank_holidays(cb) {
+    $.getJSON('https://www.gov.uk/bank-holidays.json', null, function(data) {
+      banner.addClass("alt");
+      //console.log(data);
+      var event_lst = data['england-and-wales'].events;
+      var holidays = [];
+      for (var d in event_lst) {
+        var bhd = event_lst[d].date.split('-');
+        var dt = new Date(bhd[0], bhd[1]-1, bhd[2]);
+        holidays.push(dt.getTime());
+        //console.log(bhd);
+      }
+      //console.log(holidays);
+      if (cb)
+        cb(holidays);
+    });
+  }
+
+  function getNumWorkDays(startDate, endDate, bhd) {
+      var numWorkDays = 0;
+      var currentDate = new Date(startDate);
+      while (currentDate <= endDate) {
+          // Skips Sunday and Saturday
+          if (currentDate.getDay() !== 0 && currentDate.getDay() !== 6 && (! bhd.includes(currentDate.getTime()))) {
+              numWorkDays++;
+              //console.log(currentDate);
+              //console.log(currentDate in bhd);
+          }
+          currentDate.setDate(currentDate.getDate() + 1);
+          //currentDate = currentDate.addDays(1);
+      }
+      return numWorkDays;
+  }
+
+  get_bank_holidays(function (bhd) {
+    var wd = getNumWorkDays(from, to, bhd);
+    console.log(wd);
+    if (cb)
+      cb(wd);
+  });
+}
+
+function propose_duration(selector) {
+  var from = $('#from').val();
+  var to = $('#to').val();
+  console.log(from);
+  working_days(from, to, function (wd) {
+    $(selector).val(wd);
+  });
+}
+
+
 $(function() {
 
     if(localStorage.expandedMenu==0) { $("body").addClass('sidebar-collapse'); }
@@ -56,7 +109,7 @@ $(function() {
     $('#from_datepicker').datepicker({ changeMonth: true, changeYear: true, inline: true,
         dateFormat: "yy-mm-dd", altField: "#d", altFormat: "yy-mm-dd" });
     $('#from').change(function(){ $('#from_datepicker').datepicker('setDate', $(this).val()); });
-    $('#from_datepicker').change(function(){ $('#from').attr('value',$(this).val()); });
+    $('#from_datepicker').change(function(){ $('#from').attr('value',$(this).val()); propose_duration('#duration')});
     $('#from_datepicker').datepicker('setDate', $('#from').val());
 
 

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -17,7 +17,7 @@ Dropzone.autoDiscover = false;
 
 function working_days(from, to, cb) {
   function get_bank_holidays(cb) {
-    $.getJSON('https://www.gov.uk/bank-holidays.json', null, function(data) {
+    $.getJSON('https://lcas.lincoln.ac.uk/pgr-test/api/holidays', null, function(data) {
       banner.addClass("alt");
       //console.log(data);
       var event_lst = data['england-and-wales'].events;

--- a/resources/views/admin/absence/create.blade.php
+++ b/resources/views/admin/absence/create.blade.php
@@ -65,7 +65,7 @@
           </div>
           <div class="form-group{{ $errors->has('duration') ? ' has-error' : '' }} col-md-6">
             <label for="duration">Duration (days)</label>
-            <input type="number" step="1" class="form-control" name="duration" value="{{ old('duration') }}">
+            <input id="duration" type="number" step="1" class="form-control" name="duration" value="{{ old('duration') }}">
             @if ($errors->has('duration'))
             <span class="help-block">
               <strong>{{ $errors->first('duration') }}</strong>

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -20,7 +20,8 @@
   <script>
   window.csrfToken  =  <?php echo json_encode([
   'csrfToken' => csrf_token(),
-  ]); ?>
+  ]); ?>;
+  window.url_prefix = "{{ config('app.url_prefix') }}";
   </script>
   @stack('header_scripts')
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,8 @@ Route::get('downtime-robot', 'DevController@downtimeRobot');
 Route::name('account-locked')->get('account-locked', 'DevController@accountLocked');
 
 Route::middleware('samlauth')->group(function () {
+    Route::get('api/holidays', 'ExternalAPI@getBankHolidays')->name('api.bank_holidays');
+
     Route::get('/', 'Controller@dashboard_url')->name('home');
     Route::get('logout', 'SAMLController@logout')->name('logout');
 


### PR DESCRIPTION
This is an attempt to solve #23 It uses the official API at https://www.gov.uk/bank-holidays.json to find all working days and prefills the duration field with it. This gives the same result as https://www.timeanddate.com/date/workdays.html which, I understand, is often used by officials to recalculate the dates.

a193c08179f15845f2922a3874f25b798339dd6b somewhat slipped into this: It always redirects to the student record if there is only one. Maybe @pet1330 you can explain why you had the "manage" permission check in there before?

Also, the Dockerfile now install `rmate` for easier remote maintenance of the deployed image and development: 6cba15c8077d1a3a6f01fd031147df35ec2fac84